### PR TITLE
Feature/#23 sharedresponseproperties

### DIFF
--- a/src/main/scala/castalia/StubConfigParser.scala
+++ b/src/main/scala/castalia/StubConfigParser.scala
@@ -1,15 +1,36 @@
 package castalia
 
-import castalia.model.Model.StubConfig
+import castalia.model.Model.{ResponseConfig, DefaultResponseConfig, StubConfig}
 
 
 object StubConfigParser {
 
   def parseStubConfig(jsonFile: String): StubConfig = {
-    JsonConverter.parseJson[StubConfig](jsonFile)
+    val initialConfig = JsonConverter.parseJson[StubConfig](jsonFile)
+    (initialConfig.default) match {
+      case (Some(default)) => StubConfig( initialConfig.endpoint, initialConfig.default, addDefaults(default, initialConfig.responses))
+      case _ => initialConfig
+    }
+
   }
 
   def parseStubConfigs(jsonFiles: List[String]): List[StubConfig] = {
     jsonFiles.map(parseStubConfig(_))
+  }
+
+  private def addDefaults( default: DefaultResponseConfig, responses: List[ResponseConfig]): List[ResponseConfig] =
+    (responses) match {
+      case (Nil) => Nil
+      case (first :: rest) => mix(default, first) :: addDefaults( default, rest)
+    }
+
+  private def mix(default: DefaultResponseConfig, response: ResponseConfig) = {
+    val delayOption = (default.delay, response.delay) match {
+      case (_, Some(delay)) => Some(delay)
+      case (default, _) => default
+    }
+    // future extension: httpStatusCode and response in ResponseConfig become Option, and default can be mixed in
+
+    ResponseConfig(response.ids, delayOption, response.httpStatusCode, response.response)
   }
 }

--- a/src/test/resources/jsonsimplestub.json
+++ b/src/test/resources/jsonsimplestub.json
@@ -3,7 +3,7 @@
   "responses": [
     {
       "ids": {
-        "$1": "1"
+        "1": "1"
       },
       "delay": {
         "distribution": "constant",
@@ -17,7 +17,7 @@
     },
     {
       "ids": {
-        "$1": "2"
+        "1": "2"
       },
       "delay": {
         "distribution": "constant",
@@ -31,7 +31,7 @@
     },
     {
       "ids": {
-        "$1": "3"
+        "1": "3"
       },
       "httpStatusCode": 200,
       "response": {

--- a/src/test/resources/sharedproperties.json
+++ b/src/test/resources/sharedproperties.json
@@ -1,0 +1,40 @@
+{
+  "endpoint": "somestub/$parm",
+  "delay": {
+    "distribution": "constant",
+    "mean": "100 ms"
+  },
+  "responses": [
+    {
+      "ids": {
+        "parm": "1"
+      },
+      "httpStatusCode": 200,
+      "response": {
+        "id": "een",
+        "someValue": "123123"
+      }
+    },
+    {
+      "ids": {
+        "parm": "2"
+      },
+      "httpStatusCode": 200,
+      "response": {
+        "id": "twee",
+        "someValue": "123123",
+        "someAdditionalValue": "345345"
+      }
+    },
+    {
+      "ids": {
+        "parm": "0"
+      },
+      "delay": {
+        "distribution": "constant",
+        "mean": "2 s"
+      },
+      "httpStatusCode": 404
+    }
+  ]
+}

--- a/src/test/resources/sharedproperties.json
+++ b/src/test/resources/sharedproperties.json
@@ -1,8 +1,10 @@
 {
   "endpoint": "somestub/$parm",
-  "delay": {
-    "distribution": "constant",
-    "mean": "100 ms"
+  "default": {
+    "delay": {
+      "distribution": "constant",
+      "mean": "100 ms"
+    }
   },
   "responses": [
     {

--- a/src/test/scala/castalia/JsonConverterSpec.scala
+++ b/src/test/scala/castalia/JsonConverterSpec.scala
@@ -42,6 +42,7 @@ class JsonConverterSpec extends UnitSpecBase {
 
         stubConfig.endpoint.shouldBe("somestub/$parm")
         stubConfig.default.shouldBe(Some(DefaultResponseConfig(Some(LatencyConfig("constant", "100 ms")), None, None)))
+        stubConfig.responses.head.ids.shouldBe(Some(Map(("parm", "1"))))
       }
     }
   }

--- a/src/test/scala/castalia/JsonConverterSpec.scala
+++ b/src/test/scala/castalia/JsonConverterSpec.scala
@@ -2,14 +2,14 @@ package castalia
 
 import java.io.FileNotFoundException
 
-import castalia.model.Model.{LatencyConfig, ResponseConfig, StubConfig}
+import castalia.model.Model.{DefaultResponseConfig, LatencyConfig, ResponseConfig, StubConfig}
 import org.scalatest.{Matchers, WordSpec}
 
 class JsonConverterSpec extends UnitSpecBase {
 
-  "A JsonConverter object" when {
+  "The Json Converter objects" when {
 
-    "parsing a existing json file to a matching type" should {
+    "parsing a existing json stub config file to a matching type" should {
       "return correctly parsed object" in {
         val stubconfig = JsonConverter.parseJson[StubConfig]("jsonconfiguredstub.json")
         stubconfig.endpoint.shouldBe("doublepathparam/$1/responsedata/$2")
@@ -29,11 +29,20 @@ class JsonConverterSpec extends UnitSpecBase {
     }
 
     "parsing an existing json file to a wrong type" should {
-        "throw UnmarshalException" in {
-          intercept[UnmarshalException] {
-            JsonConverter.parseJson[ResponseConfig]("jsonconfiguredstub.json")
-          }
+      "throw UnmarshalException" in {
+        intercept[UnmarshalException] {
+          JsonConverter.parseJson[ResponseConfig]("jsonconfiguredstub.json")
         }
       }
     }
+
+    "parsing a stubconfig with default" should {
+      "return correctly parsed stubconfig" in {
+        val stubConfig = JsonConverter.parseJson[StubConfig]("sharedproperties.json")
+
+        stubConfig.endpoint.shouldBe("somestub/$parm")
+        stubConfig.default.shouldBe(Some(DefaultResponseConfig(Some(LatencyConfig("constant", "100 ms")), None, None)))
+      }
+    }
+  }
 }

--- a/src/test/scala/castalia/ManagerServiceSpec.scala
+++ b/src/test/scala/castalia/ManagerServiceSpec.scala
@@ -22,7 +22,7 @@ class ManagerServiceSpec extends ServiceSpecBase with SprayJsonSupport {
 
   "posting new route" should {
     "result in status HTTP 200" in {
-      val stubConfig = new StubConfig("my/endpoint", List(ResponseConfig(None, None, OK.intValue, None)))
+      val stubConfig = new StubConfig("my/endpoint", None, List(ResponseConfig(None, None, OK.intValue, None)))
 
       receptionistMock.setAutoPilot(new AutoPilot {
         override def run(sender: ActorRef, msg: Any): AutoPilot = msg match{

--- a/src/test/scala/castalia/StubConfigParserTest.scala
+++ b/src/test/scala/castalia/StubConfigParserTest.scala
@@ -31,7 +31,7 @@ class StubConfigParserTest extends UnitSpecBase {
       stubConfig.responses(1).delay.shouldBe(Some(LatencyConfig("constant", "100 ms")))
       stubConfig.responses(1).httpStatusCode.shouldBe(200)
       stubConfig.responses(2).ids.shouldBe(Some(Map("parm" -> "0")))
-      stubConfig.responses(2).delay.shouldBe(Some(LatencyConfig("constant", "2000 ms")))
+      stubConfig.responses(2).delay.shouldBe(Some(LatencyConfig("constant", "2 s")))
       stubConfig.responses(2).httpStatusCode.shouldBe(404)
 
 

--- a/src/test/scala/castalia/StubConfigParserTest.scala
+++ b/src/test/scala/castalia/StubConfigParserTest.scala
@@ -1,0 +1,42 @@
+package castalia
+
+import castalia.StubConfigParser._
+import castalia.model.Model.LatencyConfig
+
+/**
+  * Created by Jean-Marc van Leerdam on 2016-01-21
+  */
+class StubConfigParserTest extends UnitSpecBase {
+
+  "StubConfigParser$Test" should {
+
+    "parseStubConfig processes normal json " in {
+      val stubConfig = parseStubConfig("jsonsimplestub.json")
+      stubConfig.endpoint.shouldBe("somepath/$1")
+      stubConfig.responses.size.shouldBe(3)
+      stubConfig.responses(0).ids.shouldBe(Some(Map("1" -> "1")))
+      stubConfig.responses(0).delay.shouldBe(Some(LatencyConfig("constant", "1000 ms")))
+      stubConfig.responses(0).httpStatusCode.shouldBe(200)
+
+    }
+
+    "parseStubConfig processes shared properties json " in {
+      val stubConfig = parseStubConfig("sharedproperties.json")
+      stubConfig.endpoint.shouldBe("somestub/$parm")
+      stubConfig.responses.size.shouldBe(3)
+      stubConfig.responses(0).ids.shouldBe(Some(Map("parm" -> "1")))
+      stubConfig.responses(0).delay.shouldBe(Some(LatencyConfig("constant", "100 ms")))
+      stubConfig.responses(0).httpStatusCode.shouldBe(200)
+      stubConfig.responses(1).ids.shouldBe(Some(Map("parm" -> "2")))
+      stubConfig.responses(1).delay.shouldBe(Some(LatencyConfig("constant", "100 ms")))
+      stubConfig.responses(1).httpStatusCode.shouldBe(200)
+      stubConfig.responses(2).ids.shouldBe(Some(Map("parm" -> "0")))
+      stubConfig.responses(2).delay.shouldBe(Some(LatencyConfig("constant", "2000 ms")))
+      stubConfig.responses(2).httpStatusCode.shouldBe(404)
+
+
+
+    }
+
+  }
+}

--- a/src/test/scala/castalia/actors/JsonEndpointActorSpec.scala
+++ b/src/test/scala/castalia/actors/JsonEndpointActorSpec.scala
@@ -38,5 +38,29 @@ class JsonEndpointActorSpec(_system: ActorSystem) extends ActorSpecBase(_system)
       }
     }
 
+    "use default delay from endpoint definition" in {
+      val requestString = "somestub/1"
+      val jsonConfig = parseStubConfig("sharedproperties.json")
+      val endpoint = system.actorOf(Props(new JsonEndpointActor(jsonConfig)))
+
+      within(100.millis, 200.millis) {
+        endpoint ! new RequestMatch(requestString, Uri(requestString).path, List(("parm", "1")), Nil, endpoint)
+
+        expectMsg(StubResponse(200, """{"id":"een","someValue":"123123"}"""))
+      }
+    }
+
+    "use response specific delay from endpoint definition" in {
+      val requestString = "somestub/0"
+      val jsonConfig = parseStubConfig("sharedproperties.json")
+      val endpoint = system.actorOf(Props(new JsonEndpointActor(jsonConfig)))
+
+      within(2000.millis, 2100.millis) {
+        endpoint ! new RequestMatch(requestString, Uri(requestString).path, List(("parm", "0")), Nil, endpoint)
+
+        expectMsg(StubResponse(404, ""))
+      }
+    }
+
   }
 }

--- a/src/test/scala/castalia/actors/JsonEndpointActorSpec.scala
+++ b/src/test/scala/castalia/actors/JsonEndpointActorSpec.scala
@@ -21,18 +21,18 @@ class JsonEndpointActorSpec(_system: ActorSystem) extends ActorSpecBase(_system)
         //RequestMatch(uri: String, path: Path, pathParams: Params, queryParams: Params, handler: String)
 
       within(1000.millis, 1200.millis) {
-        jsonEndpoint ! new RequestMatch(uriString, uri.path, List(("$1", "1")), Nil, jsonEndpoint)
+        jsonEndpoint ! new RequestMatch(uriString, uri.path, List(("1", "1")), Nil, jsonEndpoint)
 
         expectMsg(StubResponse(200, """{"id":"een","someValue":"123123"}"""))
       }
 
       within(100.millis, 200.millis) {
-        jsonEndpoint ! new RequestMatch(uriString, uri.path, List(("$1", "2")), Nil, jsonEndpoint)
+        jsonEndpoint ! new RequestMatch(uriString, uri.path, List(("1", "2")), Nil, jsonEndpoint)
 
         expectMsg(StubResponse(200, """{"id":"twee","someValue":"2222"}"""))
       }
       within(50.millis) {
-        jsonEndpoint ! new RequestMatch(uriString, uri.path, List(("$1", "3")), Nil, jsonEndpoint)
+        jsonEndpoint ! new RequestMatch(uriString, uri.path, List(("1", "3")), Nil, jsonEndpoint)
 
         expectMsg(StubResponse(200, """{"id":"drie","someValue":"123123"}"""))
       }

--- a/src/test/scala/castalia/actors/ManagerSpec.scala
+++ b/src/test/scala/castalia/actors/ManagerSpec.scala
@@ -17,7 +17,7 @@ class ManagerSpec(_system: ActorSystem) extends ActorSpecBase(_system) {
 
     val receptionistProbe = TestProbe()
     val manager = system.actorOf(Manager.props(receptionistProbe.ref))
-    val stubConfig = StubConfig("my/endpoint", List(ResponseConfig(None, None, OK.intValue, None)))
+    val stubConfig = StubConfig("my/endpoint", None, List(ResponseConfig(None, None, OK.intValue, None)))
 
     "ask receptionist and send back Done message" in {
       manager ! stubConfig

--- a/src/test/scala/castalia/matcher/MatcherModelSpec.scala
+++ b/src/test/scala/castalia/matcher/MatcherModelSpec.scala
@@ -1,11 +1,9 @@
 package castalia.matcher
 
-import akka.actor.{Actor, ActorSystem, ActorRef}
+import akka.actor.ActorSystem
 import akka.http.scaladsl.model.Uri
-import akka.http.scaladsl.model.Uri.Path
-import akka.testkit.{TestProbe, TestActorRef, TestKit}
+import akka.testkit.TestProbe
 import castalia.actors.ActorSpecBase
-import org.scalatest.{BeforeAndAfterEach, WordSpecLike}
 
 /**
   * Created by Jean-Marc van Leerdam on 2016-01-10

--- a/src/test/scala/castalia/matcher/MatcherModelSpec.scala
+++ b/src/test/scala/castalia/matcher/MatcherModelSpec.scala
@@ -3,7 +3,7 @@ package castalia.matcher
 import akka.actor.{Actor, ActorSystem, ActorRef}
 import akka.http.scaladsl.model.Uri
 import akka.http.scaladsl.model.Uri.Path
-import akka.testkit.{TestActorRef, TestKit}
+import akka.testkit.{TestProbe, TestActorRef, TestKit}
 import castalia.actors.ActorSpecBase
 import org.scalatest.{BeforeAndAfterEach, WordSpecLike}
 
@@ -29,7 +29,7 @@ class MatcherModelSpec (_system: ActorSystem) extends ActorSpecBase(_system) {
   "MatcherModel Matcher class" should {
 
     "support {} as path parameter indication" in {
-      val actRef = TestActorRef[Actor]
+      val actRef = TestProbe().ref
       val matcher = new Matcher(List("a", "{bparm}", "c"), actRef)
 
       val result = matcher.matchPath(List("a", "b", "c"))
@@ -38,7 +38,7 @@ class MatcherModelSpec (_system: ActorSystem) extends ActorSpecBase(_system) {
     }
 
     "support $ as path parameter indication" in {
-      val actRef = TestActorRef[Actor]
+      val actRef = TestProbe().ref
       val matcher = new Matcher(List("a", "b", "$c"), actRef)
 
       val result = matcher.matchPath(List("a", "b", "cval"))
@@ -47,7 +47,7 @@ class MatcherModelSpec (_system: ActorSystem) extends ActorSpecBase(_system) {
     }
 
     "support mixing {} and $ as path parameter" in {
-      val actRef = TestActorRef[Actor]
+      val actRef = TestProbe().ref
       val matcher = new Matcher(List("a", "{bparm}", "$c"), actRef)
 
       val result = matcher.matchPath(List("a", "b", "cval"))

--- a/src/test/scala/castalia/matcher/RequestMatcherTest.scala
+++ b/src/test/scala/castalia/matcher/RequestMatcherTest.scala
@@ -1,7 +1,7 @@
 package castalia.matcher
 
 import akka.actor.{Actor, ActorSystem}
-import akka.testkit.{TestActorRef, TestActor, TestKit}
+import akka.testkit.{TestProbe, TestActorRef, TestActor, TestKit}
 import castalia.actors.ActorSpecBase
 import org.scalatest.{WordSpecLike, BeforeAndAfterEach, Matchers, WordSpec}
 
@@ -13,8 +13,8 @@ class RequestMatcherTest(_system: ActorSystem) extends ActorSpecBase(_system) wi
   def this() = this(ActorSystem("RequestMatcherTest"))
 
   private var uriMatcher: RequestMatcher = _
-  private var a1 = TestActorRef[Actor]
-  private var a2 = TestActorRef[Actor]
+  private var a1 = TestProbe().ref
+  private var a2 = TestProbe().ref
 
   override def beforeEach() {
     val s1 = List("sample", "path", "with", "{partyId}", "id")


### PR DESCRIPTION
Implements feature 23 (adding "default" section to the stubconfig, to supply default delay (and some preparations to make httpStatusCode and response (body) optional in the future).
Includes some refactoring/code cleanup.
